### PR TITLE
fix(formatter): calculate achievable savings excluding mutually exclu…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ Thumbs.db
 *.log
 .env
 .env.*
+.playwright-mcp
 
 # IDEs
 .vscode/

--- a/__mocks__/@actions/core.js
+++ b/__mocks__/@actions/core.js
@@ -1,0 +1,38 @@
+// Manual mock for @actions/core (ESM module)
+const debug = jest.fn();
+const info = jest.fn();
+const warning = jest.fn();
+const error = jest.fn();
+const notice = jest.fn();
+const setOutput = jest.fn();
+const setFailed = jest.fn();
+const getInput = jest.fn();
+const getBooleanInput = jest.fn();
+const getMultilineInput = jest.fn();
+const exportVariable = jest.fn();
+const setSecret = jest.fn();
+const addPath = jest.fn();
+const startGroup = jest.fn();
+const endGroup = jest.fn();
+const saveState = jest.fn();
+const getState = jest.fn();
+
+module.exports = {
+  debug,
+  info,
+  warning,
+  error,
+  notice,
+  setOutput,
+  setFailed,
+  getInput,
+  getBooleanInput,
+  getMultilineInput,
+  exportVariable,
+  setSecret,
+  addPath,
+  startGroup,
+  endGroup,
+  saveState,
+  getState,
+};

--- a/__mocks__/@actions/exec.js
+++ b/__mocks__/@actions/exec.js
@@ -1,0 +1,8 @@
+// Manual mock for @actions/exec (ESM module)
+const exec = jest.fn();
+const getExecOutput = jest.fn();
+
+module.exports = {
+  exec,
+  getExecOutput,
+};

--- a/__mocks__/@actions/github.js
+++ b/__mocks__/@actions/github.js
@@ -1,0 +1,17 @@
+// Manual mock for @actions/github (ESM module)
+const context = {
+  repo: {
+    owner: '',
+    repo: '',
+  },
+  payload: {
+    pull_request: null,
+  },
+};
+
+const getOctokit = jest.fn();
+
+module.exports = {
+  context,
+  getOctokit,
+};

--- a/__mocks__/@actions/tool-cache.js
+++ b/__mocks__/@actions/tool-cache.js
@@ -1,0 +1,18 @@
+// Manual mock for @actions/tool-cache (ESM module)
+const downloadTool = jest.fn();
+const extractTar = jest.fn();
+const extractZip = jest.fn();
+const cacheDir = jest.fn();
+const cacheFile = jest.fn();
+const find = jest.fn();
+const findAllVersions = jest.fn();
+
+module.exports = {
+  downloadTool,
+  extractTar,
+  extractZip,
+  cacheDir,
+  cacheFile,
+  find,
+  findAllVersions,
+};

--- a/__tests__/unit/comment.test.ts
+++ b/__tests__/unit/comment.test.ts
@@ -2,23 +2,28 @@ import * as github from '@actions/github';
 import { Commenter } from '../../src/comment.js';
 
 jest.mock('@actions/github');
+jest.mock('@actions/core');
+
+const mockedGithub = github as jest.Mocked<typeof github>;
 
 describe('Commenter', () => {
   let commenter: Commenter;
 
   beforeEach(() => {
+    jest.clearAllMocks();
     commenter = new Commenter();
-    (github as any).context = {
+    // Set up the mocked context
+    Object.assign(mockedGithub.context, {
       repo: {
         owner: 'owner',
-        repo: 'repo'
+        repo: 'repo',
       },
       payload: {
         pull_request: {
-          number: 123
-        }
-      }
-    };
+          number: 123,
+        },
+      },
+    });
   });
 
   it('should create new comment if none exists', async () => {
@@ -26,17 +31,19 @@ describe('Commenter', () => {
       rest: {
         issues: {
           listComments: jest.fn().mockResolvedValue({ data: [] }),
-          createComment: jest.fn().mockResolvedValue({})
-        }
-      }
+          createComment: jest.fn().mockResolvedValue({}),
+        },
+      },
     };
-    (github.getOctokit as jest.Mock).mockReturnValue(octokit);
+    mockedGithub.getOctokit.mockReturnValue(octokit as any);
 
     await commenter.upsertComment({ projected_monthly_cost: 100, currency: 'USD' }, 'token');
 
-    expect(octokit.rest.issues.createComment).toHaveBeenCalledWith(expect.objectContaining({
-      body: expect.stringContaining('<!-- finfocus-action-comment -->')
-    }));
+    expect(octokit.rest.issues.createComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining('<!-- finfocus-action-comment -->'),
+      }),
+    );
   });
 
   it('should update existing comment if found', async () => {
@@ -46,19 +53,21 @@ describe('Commenter', () => {
           listComments: jest.fn().mockResolvedValue({
             data: [
               { id: 1, body: 'other comment' },
-              { id: 2, body: '<!-- finfocus-action-comment --> existing table' }
-            ]
+              { id: 2, body: '<!-- finfocus-action-comment --> existing table' },
+            ],
           }),
-          updateComment: jest.fn().mockResolvedValue({})
-        }
-      }
+          updateComment: jest.fn().mockResolvedValue({}),
+        },
+      },
     };
-    (github.getOctokit as jest.Mock).mockReturnValue(octokit);
+    mockedGithub.getOctokit.mockReturnValue(octokit as any);
 
     await commenter.upsertComment({ projected_monthly_cost: 100, currency: 'USD' }, 'token');
 
-    expect(octokit.rest.issues.updateComment).toHaveBeenCalledWith(expect.objectContaining({
-      comment_id: 2
-    }));
+    expect(octokit.rest.issues.updateComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        comment_id: 2,
+      }),
+    );
   });
 });

--- a/__tests__/unit/formatter.test.ts
+++ b/__tests__/unit/formatter.test.ts
@@ -1,5 +1,5 @@
-import { formatCommentBody } from '../../src/formatter.js';
-import { FinfocusReport, ActionConfiguration, ActualCostReport, BudgetHealthReport } from '../../src/types.js';
+import { formatCommentBody, calculateAchievableSavings } from '../../src/formatter.js';
+import { FinfocusReport, ActionConfiguration, ActualCostReport, BudgetHealthReport, Recommendation } from '../../src/types.js';
 
 describe('formatCommentBody', () => {
   const mockReport: FinfocusReport = {
@@ -10,12 +10,126 @@ describe('formatCommentBody', () => {
     },
   };
 
+  describe('Dashboard Summary', () => {
+    it('should display 3-column dashboard summary table', () => {
+      const result = formatCommentBody(mockReport);
+
+      expect(result).toContain('💰 Monthly Cost');
+      expect(result).toContain('📊 Budget Status');
+      expect(result).toContain('💡 Potential Savings');
+      expect(result).toContain('**$100.50** USD');
+    });
+
+    it('should show budget percentage in dashboard when budget configured', () => {
+      const budgetStatus = {
+        configured: true,
+        amount: 200.0,
+        currency: 'USD',
+        period: 'monthly',
+        spent: 100.5,
+        remaining: 99.5,
+        percentUsed: 50.25,
+        alerts: [],
+      };
+
+      const result = formatCommentBody(mockReport, undefined, undefined, undefined, undefined, budgetStatus);
+
+      expect(result).toContain('**50%** used');
+      expect(result).toContain('🟡'); // 50% shows yellow
+    });
+
+    it('should show green status when budget usage below 50%', () => {
+      const budgetStatus = {
+        configured: true,
+        amount: 500.0,
+        currency: 'USD',
+        period: 'monthly',
+        spent: 100.5,
+        remaining: 399.5,
+        percentUsed: 20.1,
+        alerts: [],
+      };
+
+      const result = formatCommentBody(mockReport, undefined, undefined, undefined, undefined, budgetStatus);
+
+      expect(result).toContain('🟢');
+      expect(result).toContain('**20%** used');
+    });
+
+    it('should show red status when budget usage 80-99%', () => {
+      const budgetStatus = {
+        configured: true,
+        amount: 120.0,
+        currency: 'USD',
+        period: 'monthly',
+        spent: 100.5,
+        remaining: 19.5,
+        percentUsed: 83.75,
+        alerts: [],
+      };
+
+      const result = formatCommentBody(mockReport, undefined, undefined, undefined, undefined, budgetStatus);
+
+      expect(result).toContain('🔴');
+      expect(result).toContain('**84%** used');
+    });
+
+    it('should show stop sign when budget exceeded', () => {
+      const budgetStatus = {
+        configured: true,
+        amount: 80.0,
+        currency: 'USD',
+        period: 'monthly',
+        spent: 100.5,
+        remaining: -20.5,
+        percentUsed: 125.625,
+        alerts: [],
+      };
+
+      const result = formatCommentBody(mockReport, undefined, undefined, undefined, undefined, budgetStatus);
+
+      expect(result).toContain('⛔');
+      expect(result).toContain('**126%** used');
+    });
+
+    it('should show potential savings in dashboard when recommendations available', () => {
+      const recommendations = {
+        summary: {
+          total_savings: 23.21,
+          currency: 'USD',
+        },
+        recommendations: [
+          {
+            resource_id: 'test-resource',
+            description: 'Resize instance',
+            estimated_savings: 23.21,
+            currency: 'USD',
+          },
+        ],
+      };
+
+      const result = formatCommentBody(mockReport, undefined, recommendations);
+
+      expect(result).toContain('**$23.21**/mo');
+    });
+
+    it('should show dash when no budget or savings data', () => {
+      const result = formatCommentBody(mockReport);
+
+      // Budget column should show dash
+      expect(result).toMatch(/📊 Budget Status.*\n.*\n.*—/);
+      // Savings column should show dash
+      expect(result).toMatch(/💡 Potential Savings.*\n.*\n.*—/);
+    });
+  });
+
   it('should format basic cost estimate without actual costs', () => {
     const result = formatCommentBody(mockReport);
 
-    expect(result).toContain('## 💰 Cloud Cost Estimate');
+    expect(result).toContain('## Cloud Cost Estimate');
     expect(result).toContain('Projected Monthly');
     expect(result).toContain('100.50 USD');
+    // Multiple providers should show Cost by Provider section
     expect(result).toContain('Cost by Provider');
     expect(result).toContain('aws');
     expect(result).toContain('gcp');
@@ -42,7 +156,7 @@ describe('formatCommentBody', () => {
 
     expect(result).toContain('Actual (7d)');
     expect(result).toContain('85.30 USD');
-    expect(result).toContain('Actual Costs by provider');
+    expect(result).toContain('Actual Costs');
     expect(result).toContain('2025-01-01 to 2025-01-08');
   });
 
@@ -58,7 +172,7 @@ describe('formatCommentBody', () => {
     const result = formatCommentBody(mockReport, undefined, undefined, actualReport);
 
     expect(result).not.toContain('Actual');
-    expect(result).not.toContain('Actual Costs by');
+    expect(result).not.toContain('Actual Costs');
   });
 
   it('should handle cost differences correctly', () => {
@@ -99,7 +213,7 @@ describe('formatCommentBody', () => {
 
     const result = formatCommentBody(reportWithResources);
 
-    expect(result).toContain('Top Resources by Cost');
+    expect(result).toContain('Top Resources');
     expect(result).toContain('Instance');
     expect(result).toContain('Bucket');
     expect(result).toContain('50.00 USD');
@@ -110,17 +224,17 @@ describe('formatCommentBody', () => {
     const sustainabilityReport = {
       totalCO2e: 125.5,
       totalCO2eDiff: 15.2,
-      carbonIntensity: 2.95
+      carbonIntensity: 2.95,
     };
 
     const config: ActionConfiguration = {
       includeSustainability: true,
-      sustainabilityEquivalents: true
+      sustainabilityEquivalents: true,
     } as ActionConfiguration;
 
     const result = formatCommentBody(mockReport, config, undefined, undefined, sustainabilityReport);
 
-    expect(result).toContain('🌱 Sustainability Impact');
+    expect(result).toContain('Sustainability');
     expect(result).toContain('Carbon Footprint');
     expect(result).toContain('125.50 kgCO₂e/month');
     expect(result).toContain('Carbon Change');
@@ -132,8 +246,8 @@ describe('formatCommentBody', () => {
     expect(result).toContain('313.75 miles');
   });
 
-  describe('TUI Budget Display', () => {
-    it('should include TUI-style budget box when budget is configured', () => {
+  describe('Budget Status Display', () => {
+    it('should use GitHub alert syntax when budget is configured', () => {
       const budgetStatus = {
         configured: true,
         amount: 1000.0,
@@ -147,16 +261,12 @@ describe('formatCommentBody', () => {
 
       const result = formatCommentBody(mockReport, undefined, undefined, undefined, undefined, budgetStatus);
 
-      // Check for TUI box structure
-      expect(result).toContain('```');
-      expect(result).toContain('╭');
-      expect(result).toContain('╮');
-      expect(result).toContain('╰');
-      expect(result).toContain('╯');
-      expect(result).toContain('│');
-      expect(result).toContain('BUDGET STATUS');
-      expect(result).toContain('Budget: $1000.00/monthly');
-      expect(result).toContain('Current Spend: $850.00 (85.0%)');
+      // Should use GitHub alert syntax
+      expect(result).toContain('[!');
+      expect(result).toContain('Budget');
+      expect(result).toContain('$1000.00/monthly');
+      expect(result).toContain('$850.00');
+      expect(result).toContain('85%');
     });
 
     it('should show progress bar with block characters', () => {
@@ -174,12 +284,12 @@ describe('formatCommentBody', () => {
       const result = formatCommentBody(mockReport, undefined, undefined, undefined, undefined, budgetStatus);
 
       // Check for block characters in progress bar
-      expect(result).toContain('█'); // Filled blocks
+      expect(result).toContain('▓'); // Filled blocks
       expect(result).toContain('░'); // Empty blocks
       expect(result).toContain('85%');
     });
 
-    it('should show WARNING message when budget usage exceeds 80%', () => {
+    it('should show WARNING alert type when budget usage exceeds 80%', () => {
       const budgetStatus = {
         configured: true,
         amount: 1000.0,
@@ -193,10 +303,11 @@ describe('formatCommentBody', () => {
 
       const result = formatCommentBody(mockReport, undefined, undefined, undefined, undefined, budgetStatus);
 
-      expect(result).toContain('⚠ WARNING - spend exceeds 80% threshold');
+      expect(result).toContain('[!WARNING]');
+      expect(result).toContain('Budget Warning');
     });
 
-    it('should show CRITICAL message when budget is exceeded', () => {
+    it('should show CAUTION alert type when budget is exceeded', () => {
       const budgetStatus = {
         configured: true,
         amount: 1000.0,
@@ -210,10 +321,11 @@ describe('formatCommentBody', () => {
 
       const result = formatCommentBody(mockReport, undefined, undefined, undefined, undefined, budgetStatus);
 
-      expect(result).toContain('⚠ CRITICAL - budget exceeded');
+      expect(result).toContain('[!CAUTION]');
+      expect(result).toContain('Budget Exceeded');
     });
 
-    it('should not show warning message when budget usage is below 80%', () => {
+    it('should show NOTE alert type when budget usage is below 80%', () => {
       const budgetStatus = {
         configured: true,
         amount: 1000.0,
@@ -227,27 +339,31 @@ describe('formatCommentBody', () => {
 
       const result = formatCommentBody(mockReport, undefined, undefined, undefined, undefined, budgetStatus);
 
-      expect(result).not.toContain('⚠ WARNING');
-      expect(result).not.toContain('⚠ CRITICAL');
+      expect(result).toContain('[!NOTE]');
+      expect(result).not.toContain('Budget Warning');
+      expect(result).not.toContain('Budget Exceeded');
     });
 
-    it('should not include budget section when budget is not configured', () => {
+    it('should not include budget alert section when budget is not configured', () => {
       const budgetStatus = {
         configured: false,
       };
 
       const result = formatCommentBody(mockReport, undefined, undefined, undefined, undefined, budgetStatus);
 
-      expect(result).not.toContain('BUDGET STATUS');
-      expect(result).not.toContain('╭');
-      expect(result).not.toContain('╮');
+      // Dashboard header "📊 Budget Status" will always be present, but no alert block
+      expect(result).not.toContain('[!NOTE]');
+      expect(result).not.toContain('[!WARNING]');
+      expect(result).not.toContain('[!CAUTION]');
+      // Dashboard should show dash for budget
+      expect(result).toMatch(/📊 Budget Status.*\n.*\n.*—/);
     });
 
     it('should not include budget section when budgetStatus is undefined', () => {
       const result = formatCommentBody(mockReport);
 
-      expect(result).not.toContain('BUDGET STATUS');
-      expect(result).not.toContain('╭');
+      // No budget-related alert blocks
+      expect(result).not.toMatch(/>\s*\[!/);
     });
 
     it('should include alerts when triggered', () => {
@@ -267,7 +383,7 @@ describe('formatCommentBody', () => {
 
       const result = formatCommentBody(mockReport, undefined, undefined, undefined, undefined, budgetStatus);
 
-      expect(result).toContain('💰 80% actual threshold exceeded');
+      expect(result).toContain('80% actual threshold exceeded');
       expect(result).not.toContain('50% projected threshold exceeded');
     });
 
@@ -311,7 +427,7 @@ describe('formatCommentBody', () => {
     it('should display health score with healthy status icon (green)', () => {
       const result = formatCommentBody(mockReport, undefined, undefined, undefined, undefined, undefined, baseBudgetHealth);
 
-      expect(result).toContain('BUDGET HEALTH');
+      expect(result).toContain('Budget Health');
       expect(result).toContain('🟢');
       expect(result).toContain('85/100');
     });
@@ -355,7 +471,7 @@ describe('formatCommentBody', () => {
       const result = formatCommentBody(mockReport, undefined, undefined, undefined, undefined, undefined, exceededHealth);
 
       expect(result).toContain('⛔');
-      expect(result).toContain('exceeded');
+      expect(result).toContain('Exceeded');
     });
 
     it('should display forecast when showBudgetForecast is true (default)', () => {
@@ -365,8 +481,8 @@ describe('formatCommentBody', () => {
 
       const result = formatCommentBody(mockReport, config, undefined, undefined, undefined, undefined, baseBudgetHealth);
 
-      expect(result).toContain('Forecast: $1,890.00');
-      expect(result).toContain('end of period');
+      expect(result).toContain('Forecast');
+      expect(result).toContain('$1,890.00');
     });
 
     it('should hide forecast when showBudgetForecast is false', () => {
@@ -382,46 +498,35 @@ describe('formatCommentBody', () => {
     it('should display runway days', () => {
       const result = formatCommentBody(mockReport, undefined, undefined, undefined, undefined, undefined, baseBudgetHealth);
 
-      expect(result).toContain('Runway: 12 days remaining');
+      expect(result).toContain('Runway');
+      expect(result).toContain('12 days');
     });
 
-    it('should display TUI box with progress bar', () => {
+    it('should use GitHub alert syntax with progress bar', () => {
       const result = formatCommentBody(mockReport, undefined, undefined, undefined, undefined, undefined, baseBudgetHealth);
 
-      expect(result).toContain('```');
-      expect(result).toContain('╭');
-      expect(result).toContain('╮');
-      expect(result).toContain('╰');
-      expect(result).toContain('╯');
-      expect(result).toContain('█');
-      expect(result).toContain('░');
+      // Should use GitHub alert syntax
+      expect(result).toContain('[!NOTE]');
+      expect(result).toContain('▓'); // Filled blocks
+      expect(result).toContain('░'); // Empty blocks
     });
 
-    it('should show alert when percentUsed exceeds budgetAlertThreshold', () => {
-      const config: ActionConfiguration = {
-        budgetAlertThreshold: 60,
-      } as ActionConfiguration;
-
-      const result = formatCommentBody(mockReport, config, undefined, undefined, undefined, undefined, baseBudgetHealth);
-
-      expect(result).toContain('⚠ WARNING');
-      expect(result).toContain('60%');
-    });
-
-    it('should not show alert when percentUsed is below budgetAlertThreshold', () => {
-      const config: ActionConfiguration = {
-        budgetAlertThreshold: 80,
-      } as ActionConfiguration;
-
-      const lowUsageHealth: BudgetHealthReport = {
+    it('should use WARNING alert type when health status is warning', () => {
+      const warningHealth: BudgetHealthReport = {
         ...baseBudgetHealth,
-        percentUsed: 50,
-        healthStatus: 'healthy',
+        healthStatus: 'warning',
       };
 
-      const result = formatCommentBody(mockReport, config, undefined, undefined, undefined, undefined, lowUsageHealth);
+      const result = formatCommentBody(mockReport, undefined, undefined, undefined, undefined, undefined, warningHealth);
 
-      expect(result).not.toContain('⚠ WARNING');
+      expect(result).toContain('[!WARNING]');
+    });
+
+    it('should not show warning when health status is healthy', () => {
+      const result = formatCommentBody(mockReport, undefined, undefined, undefined, undefined, undefined, baseBudgetHealth);
+
+      expect(result).not.toContain('[!WARNING]');
+      expect(result).not.toContain('[!CAUTION]');
     });
 
     it('should prefer BudgetHealthReport over BudgetStatus when both provided', () => {
@@ -437,9 +542,137 @@ describe('formatCommentBody', () => {
 
       const result = formatCommentBody(mockReport, undefined, undefined, undefined, undefined, budgetStatus, baseBudgetHealth);
 
-      // Should show BUDGET HEALTH (from BudgetHealthReport), not BUDGET STATUS (from BudgetStatus)
-      expect(result).toContain('BUDGET HEALTH');
+      // Should show Budget Health (from BudgetHealthReport), not Budget Status (from BudgetStatus)
+      expect(result).toContain('Budget Health');
       expect(result).toContain('85/100');
     });
+  });
+});
+
+describe('calculateAchievableSavings', () => {
+  it('should return 0 for empty recommendations array', () => {
+    expect(calculateAchievableSavings([])).toBe(0);
+  });
+
+  it('should return 0 for undefined recommendations', () => {
+    expect(calculateAchievableSavings(undefined as unknown as Recommendation[])).toBe(0);
+  });
+
+  it('should sum savings when all recommendations are for different resources', () => {
+    const recommendations: Recommendation[] = [
+      { resource_id: 'ec2-instance-1', action_type: 'RIGHTSIZING', description: 'Resize', estimated_savings: 50, currency: 'USD' },
+      { resource_id: 'ebs-volume-1', action_type: 'DELETE', description: 'Delete unused', estimated_savings: 20, currency: 'USD' },
+    ];
+
+    expect(calculateAchievableSavings(recommendations)).toBe(70);
+  });
+
+  it('should take max savings when multiple options exist for same resource+action_type', () => {
+    // Same resource, same action type = mutually exclusive options
+    const recommendations: Recommendation[] = [
+      { resource_id: 'ec2-instance-1', action_type: 'RIGHTSIZING', description: 'Resize to medium', estimated_savings: 50, currency: 'USD' },
+      { resource_id: 'ec2-instance-1', action_type: 'RIGHTSIZING', description: 'Resize to small', estimated_savings: 80, currency: 'USD' },
+    ];
+
+    // Should be max(50, 80) = 80, not 50 + 80 = 130
+    expect(calculateAchievableSavings(recommendations)).toBe(80);
+  });
+
+  it('should handle mixed scenarios correctly (issue example)', () => {
+    // Example from the GitHub issue:
+    // EC2 has two RIGHTSIZING options (mutually exclusive): $50 and $80
+    // EBS has one DELETE option: $20
+    // Wrong calculation: $50 + $80 + $20 = $150
+    // Correct calculation: max($50, $80) + $20 = $100
+    const recommendations: Recommendation[] = [
+      { resource_id: 'ec2-instance-1', action_type: 'RIGHTSIZING', description: 'Resize large → medium', estimated_savings: 50, currency: 'USD' },
+      { resource_id: 'ec2-instance-1', action_type: 'RIGHTSIZING', description: 'Resize large → small', estimated_savings: 80, currency: 'USD' },
+      { resource_id: 'ebs-volume-unused', action_type: 'DELETE', description: 'Remove unused EBS volume', estimated_savings: 20, currency: 'USD' },
+    ];
+
+    expect(calculateAchievableSavings(recommendations)).toBe(100);
+  });
+
+  it('should allow same resource with different action types to sum', () => {
+    // Same resource, different action types = NOT mutually exclusive
+    const recommendations: Recommendation[] = [
+      { resource_id: 'ec2-instance-1', action_type: 'RIGHTSIZING', description: 'Resize to small', estimated_savings: 50, currency: 'USD' },
+      { resource_id: 'ec2-instance-1', action_type: 'SCHEDULING', description: 'Stop during off-hours', estimated_savings: 30, currency: 'USD' },
+    ];
+
+    // Different action types should sum: 50 + 30 = 80
+    expect(calculateAchievableSavings(recommendations)).toBe(80);
+  });
+
+  it('should handle multiple groups with multiple options each', () => {
+    const recommendations: Recommendation[] = [
+      // Group 1: ec2-1 + RIGHTSIZING (3 options)
+      { resource_id: 'ec2-1', action_type: 'RIGHTSIZING', description: 'Option A', estimated_savings: 10, currency: 'USD' },
+      { resource_id: 'ec2-1', action_type: 'RIGHTSIZING', description: 'Option B', estimated_savings: 25, currency: 'USD' },
+      { resource_id: 'ec2-1', action_type: 'RIGHTSIZING', description: 'Option C', estimated_savings: 15, currency: 'USD' },
+      // Group 2: rds-1 + RIGHTSIZING (2 options)
+      { resource_id: 'rds-1', action_type: 'RIGHTSIZING', description: 'Option A', estimated_savings: 100, currency: 'USD' },
+      { resource_id: 'rds-1', action_type: 'RIGHTSIZING', description: 'Option B', estimated_savings: 75, currency: 'USD' },
+      // Group 3: ebs-1 + DELETE (1 option)
+      { resource_id: 'ebs-1', action_type: 'DELETE', description: 'Delete', estimated_savings: 5, currency: 'USD' },
+    ];
+
+    // max(10,25,15) + max(100,75) + 5 = 25 + 100 + 5 = 130
+    expect(calculateAchievableSavings(recommendations)).toBe(130);
+  });
+});
+
+describe('Dashboard Achievable Savings', () => {
+  const mockReport: FinfocusReport = {
+    summary: {
+      totalMonthly: 100.5,
+      totalHourly: 0.14,
+      currency: 'USD',
+    },
+  };
+
+  it('should show achievable savings (max per group) in dashboard, not raw total', () => {
+    // Issue example: raw total would be $150, achievable is $100
+    const recommendations = {
+      summary: {
+        total_count: 3,
+        total_savings: 150, // Raw sum: 50 + 80 + 20
+        currency: 'USD',
+        count_by_action_type: { RIGHTSIZING: 2, DELETE: 1 },
+      },
+      recommendations: [
+        { resource_id: 'ec2-instance-1', action_type: 'RIGHTSIZING', description: 'Resize to medium', estimated_savings: 50, currency: 'USD' },
+        { resource_id: 'ec2-instance-1', action_type: 'RIGHTSIZING', description: 'Resize to small', estimated_savings: 80, currency: 'USD' },
+        { resource_id: 'ebs-volume-unused', action_type: 'DELETE', description: 'Remove unused', estimated_savings: 20, currency: 'USD' },
+      ],
+    };
+
+    const result = formatCommentBody(mockReport, undefined, recommendations);
+
+    // Dashboard should show achievable savings ($100), not raw total ($150)
+    expect(result).toContain('**$100.00**/mo');
+    // But recommendations section should still show "up to" raw total
+    expect(result).toContain('Save up to <strong>150.00 USD/mo</strong>');
+  });
+
+  it('should show same value when no mutually exclusive options exist', () => {
+    const recommendations = {
+      summary: {
+        total_count: 2,
+        total_savings: 70, // 50 + 20, no mutually exclusive options
+        currency: 'USD',
+        count_by_action_type: { RIGHTSIZING: 1, DELETE: 1 },
+      },
+      recommendations: [
+        { resource_id: 'ec2-instance-1', action_type: 'RIGHTSIZING', description: 'Resize', estimated_savings: 50, currency: 'USD' },
+        { resource_id: 'ebs-volume-unused', action_type: 'DELETE', description: 'Remove unused', estimated_savings: 20, currency: 'USD' },
+      ],
+    };
+
+    const result = formatCommentBody(mockReport, undefined, recommendations);
+
+    // Both dashboard and recommendations section should show $70
+    expect(result).toContain('**$70.00**/mo');
+    expect(result).toContain('Save up to <strong>70.00 USD/mo</strong>');
   });
 });

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,8 +11,15 @@ export default {
       },
     ],
   },
+  transformIgnorePatterns: [
+    'node_modules/(?!(@actions/github)/)',
+  ],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   moduleNameMapper: {
+    '^@actions/core$': '<rootDir>/__mocks__/@actions/core.js',
+    '^@actions/exec$': '<rootDir>/__mocks__/@actions/exec.js',
+    '^@actions/github$': '<rootDir>/__mocks__/@actions/github.js',
+    '^@actions/tool-cache$': '<rootDir>/__mocks__/@actions/tool-cache.js',
     '^(\\.\\.?/.+)\\.js$': '$1',
   },
   testMatch: ['**/__tests__/**/*.test.ts'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@actions/core": "^2.0.2",
+        "@actions/core": "^3.0.0",
         "@actions/exec": "^3.0.0",
-        "@actions/github": "^7.0.0",
-        "@actions/tool-cache": "^3.0.0",
+        "@actions/github": "^9.0.0",
+        "@actions/tool-cache": "^4.0.0",
         "typescript": "^5.9.3",
         "yaml": "^2.8.2"
       },
@@ -41,22 +41,23 @@
       }
     },
     "node_modules/@actions/core": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-2.0.3.tgz",
-      "integrity": "sha512-Od9Thc3T1mQJYddvVPM4QGiLUewdh+3txmDYHHxoNdkqysR1MbCT+rFOtNUxYAz+7+6RIsqipVahY2GJqGPyxA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-zYt6cz+ivnTmiT/ksRVriMBOiuoUpDCJJlZ5KPl2/FRdvwU3f7MPh9qftvbkXJThragzUZieit2nyHUyw53Seg==",
       "license": "MIT",
       "dependencies": {
-        "@actions/exec": "^2.0.0",
-        "@actions/http-client": "^3.0.2"
+        "@actions/exec": "^3.0.0",
+        "@actions/http-client": "^4.0.0"
       }
     },
-    "node_modules/@actions/core/node_modules/@actions/exec": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-2.0.0.tgz",
-      "integrity": "sha512-k8ngrX2voJ/RIN6r9xB82NVqKpnMRtxDoiO+g3olkIUpQNqjArXrCQceduQZCQj3P3xm32pChRLqRrtXTlqhIw==",
+    "node_modules/@actions/core/node_modules/@actions/http-client": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.0.tgz",
+      "integrity": "sha512-QuwPsgVMsD6qaPD57GLZi9sqzAZCtiJT8kVBCDpLtxhL5MydQ4gS+DrejtZZPdIYyB1e95uCK9Luyds7ybHI3g==",
       "license": "MIT",
       "dependencies": {
-        "@actions/io": "^2.0.0"
+        "tunnel": "^0.0.6",
+        "undici": "^6.23.0"
       }
     },
     "node_modules/@actions/exec": {
@@ -68,26 +69,159 @@
         "@actions/io": "^3.0.2"
       }
     },
-    "node_modules/@actions/exec/node_modules/@actions/io": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
-      "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
-      "license": "MIT"
-    },
     "node_modules/@actions/github": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/github/-/github-7.0.0.tgz",
-      "integrity": "sha512-PyGODO938aoBTZd/IfN/+e+Pd5hUcVpyf+thm4CPESLeqhdSkq5QwMTGX9v84XHE1ifmHWBQ60KB8kIgm96opw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-9.0.0.tgz",
+      "integrity": "sha512-yJ0RoswsAaKcvkmpCE4XxBRiy/whH2SdTBHWzs0gi4wkqTDhXMChjSdqBz/F4AeiDlP28rQqL33iHb+kjAMX6w==",
       "license": "MIT",
       "dependencies": {
-        "@actions/http-client": "^3.0.1",
-        "@octokit/core": "^5.0.1",
-        "@octokit/plugin-paginate-rest": "^9.2.2",
-        "@octokit/plugin-rest-endpoint-methods": "^10.4.0",
-        "@octokit/request": "^8.4.1",
-        "@octokit/request-error": "^5.1.1",
-        "undici": "^5.28.5"
+        "@actions/http-client": "^3.0.2",
+        "@octokit/core": "^7.0.6",
+        "@octokit/plugin-paginate-rest": "^14.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^17.0.0",
+        "@octokit/request": "^10.0.7",
+        "@octokit/request-error": "^7.1.0",
+        "undici": "^6.23.0"
       }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/auth-token": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/core": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
+      "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^6.0.0",
+        "@octokit/graphql": "^9.0.3",
+        "@octokit/request": "^10.0.6",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "before-after-hook": "^4.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/endpoint": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.2.tgz",
+      "integrity": "sha512-4zCpzP1fWc7QlqunZ5bSEjxc6yLAlRTnDwKtgXfcI/FxxGoqedDG8V2+xJ60bV2kODqcGB+nATdtap/XYq2NZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/graphql": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
+      "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "license": "MIT"
+    },
+    "node_modules/@actions/github/node_modules/@octokit/plugin-paginate-rest": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+      "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
+      "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/request": {
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.7.tgz",
+      "integrity": "sha512-v93h0i1yu4idj8qFPZwjehoJx4j3Ntn+JhXsdJrG9pYaX6j/XRz2RmasMUHtNgQD39nrv/VwTWSqK0RNXR8upA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.2",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "fast-content-type-parse": "^3.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/request-error": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+      "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
+      }
+    },
+    "node_modules/@actions/github/node_modules/before-after-hook": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@actions/github/node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "license": "ISC"
     },
     "node_modules/@actions/http-client": {
       "version": "3.0.2",
@@ -99,41 +233,45 @@
         "undici": "^6.23.0"
       }
     },
-    "node_modules/@actions/http-client/node_modules/undici": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
-      }
-    },
     "node_modules/@actions/io": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/io/-/io-2.0.0.tgz",
-      "integrity": "sha512-Jv33IN09XLO+0HS79aaODsvIRyduiF7NY/F6LYeK5oeUmrsz7aFdRphQjFoESF4jS7lMauDOttKALcpapVDIAg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
+      "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
       "license": "MIT"
     },
     "node_modules/@actions/tool-cache": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@actions/tool-cache/-/tool-cache-3.0.1.tgz",
-      "integrity": "sha512-euK7sID37jMg1yWGkdXkLPI5Te7x/+2QMUPeHXogcpzUZ81mqlDZ+CgYhQo3LtB8LpVnnQyjs+hTTU0Ir4Y0RQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/tool-cache/-/tool-cache-4.0.0.tgz",
+      "integrity": "sha512-L8P9HbXvpvqjZDveb/fdsa55IVC0trfPgQ4ZwGo6r5af6YDVdM9vMGPZ7rgY2fAT9gGj4PSYd6bYlg3p3jD78A==",
       "license": "MIT",
       "dependencies": {
-        "@actions/core": "^2.0.1",
-        "@actions/exec": "^2.0.0",
-        "@actions/http-client": "^3.0.2",
-        "@actions/io": "^2.0.0",
-        "semver": "^6.1.0"
+        "@actions/core": "^3.0.0",
+        "@actions/exec": "^3.0.0",
+        "@actions/http-client": "^4.0.0",
+        "@actions/io": "^3.0.0",
+        "semver": "^7.7.3"
       }
     },
-    "node_modules/@actions/tool-cache/node_modules/@actions/exec": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-2.0.0.tgz",
-      "integrity": "sha512-k8ngrX2voJ/RIN6r9xB82NVqKpnMRtxDoiO+g3olkIUpQNqjArXrCQceduQZCQj3P3xm32pChRLqRrtXTlqhIw==",
+    "node_modules/@actions/tool-cache/node_modules/@actions/http-client": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.0.tgz",
+      "integrity": "sha512-QuwPsgVMsD6qaPD57GLZi9sqzAZCtiJT8kVBCDpLtxhL5MydQ4gS+DrejtZZPdIYyB1e95uCK9Luyds7ybHI3g==",
       "license": "MIT",
       "dependencies": {
-        "@actions/io": "^2.0.0"
+        "tunnel": "^0.0.6",
+        "undici": "^6.23.0"
+      }
+    },
+    "node_modules/@actions/tool-cache/node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -167,7 +305,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2080,312 +2217,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
-      "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
-      "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
-      "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
-      "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
-      "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
-      "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
-      "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
-      "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
-      "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
-      "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
-      "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
-      "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
-      "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
-      "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
-      "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
-      "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@esbuild/linux-x64": {
       "version": "0.27.2",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
@@ -2398,159 +2229,6 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
-      "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
-      "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
-      "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
-      "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
-      "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
-      "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
-      "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -2743,15 +2421,6 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@humanfs/core": {
@@ -3657,178 +3326,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
-      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "^1.4.3",
-        "@emnapi/runtime": "^1.4.3",
-        "@tybys/wasm-util": "^0.10.0"
-      }
-    },
-    "node_modules/@octokit/auth-token": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
-      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/core": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
-      "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@octokit/auth-token": "^4.0.0",
-        "@octokit/graphql": "^7.1.0",
-        "@octokit/request": "^8.4.1",
-        "@octokit/request-error": "^5.1.1",
-        "@octokit/types": "^13.0.0",
-        "before-after-hook": "^2.2.0",
-        "universal-user-agent": "^6.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/endpoint": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
-      "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^13.1.0",
-        "universal-user-agent": "^6.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/graphql": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
-      "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/request": "^8.4.1",
-        "@octokit/types": "^13.0.0",
-        "universal-user-agent": "^6.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/openapi-types": {
-      "version": "24.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
-      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
-      "license": "MIT"
-    },
-    "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.2.tgz",
-      "integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^12.6.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@octokit/core": "5"
-      }
-    },
-    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
-      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
-      "license": "MIT"
-    },
-    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
-      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^20.0.0"
-      }
-    },
-    "node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
-      "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^12.6.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@octokit/core": "5"
-      }
-    },
-    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
-      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
-      "license": "MIT"
-    },
-    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
-      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^20.0.0"
-      }
-    },
-    "node_modules/@octokit/request": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
-      "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/endpoint": "^9.0.6",
-        "@octokit/request-error": "^5.1.1",
-        "@octokit/types": "^13.1.0",
-        "universal-user-agent": "^6.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/request-error": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
-      "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^13.1.0",
-        "deprecation": "^2.0.0",
-        "once": "^1.4.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/types": {
-      "version": "13.10.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
-      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^24.2.0"
-      }
-    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -3907,17 +3404,6 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4032,7 +3518,6 @@
       "integrity": "sha512-+0/4J266CBGPUq/ELg7QUHhN25WYjE0wYTPSQJn1xeu8DOlIOPxXxrNGiLmfAWl7HMMgWFWXpt9IDjMWrF5Iow==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -4067,7 +3552,6 @@
       "integrity": "sha512-hAAP5io/7csFStuOmR782YmTthKBJ9ND3WVL60hcOjvtGFb+HJxH4O5huAcmcZ9v9G8P+JETiZ/G1B8MALnWZQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.54.0",
@@ -4097,7 +3581,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -4316,188 +3799,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
-      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-android-arm64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
-      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-darwin-arm64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
-      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-darwin-x64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
-      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-freebsd-x64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
-      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
-      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
-      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
-      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
-      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
-      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
-      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
-      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
-      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
     "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
@@ -4526,65 +3827,6 @@
         "linux"
       ]
     },
-    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
-      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@napi-rs/wasm-runtime": "^0.2.11"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
-      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
-      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
-      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
     "node_modules/@vercel/ncc": {
       "version": "0.38.4",
       "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.4.tgz",
@@ -4601,7 +3843,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5043,12 +4284,6 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
-    "node_modules/before-after-hook": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
-      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
-      "license": "Apache-2.0"
-    },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -5092,7 +4327,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5539,12 +4773,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/deprecation": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
-      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
-      "license": "ISC"
-    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -5639,7 +4867,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5953,7 +5180,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6470,6 +5696,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/fast-content-type-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
+      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -6624,21 +5866,6 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -7340,7 +6567,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -8983,6 +8209,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -9910,6 +9137,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -10510,7 +9738,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10678,7 +9905,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -10716,14 +9942,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -10805,7 +10023,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10853,15 +10070,12 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
+      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
       "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {
@@ -10940,12 +10154,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/universal-user-agent": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
-      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
-      "license": "ISC"
     },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
@@ -11231,6 +10439,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {

--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
   },
   "homepage": "https://github.com/rshade/finfocus-action#readme",
   "dependencies": {
-    "@actions/core": "^2.0.2",
+    "@actions/core": "^3.0.0",
     "@actions/exec": "^3.0.0",
-    "@actions/github": "^7.0.0",
-    "@actions/tool-cache": "^3.0.0",
+    "@actions/github": "^9.0.0",
+    "@actions/tool-cache": "^4.0.0",
     "typescript": "^5.9.3",
     "yaml": "^2.8.2"
   },


### PR DESCRIPTION
…sive options

## Summary

The dashboard "Potential Savings" figure was incorrectly summing ALL recommendation savings, but finfocus CLI returns multiple options per resource_id + action_type to give users choices. Since users can only pick ONE option per resource/action, the total was inflated. This fix groups recommendations by resource_id + action_type and takes the max savings per group for an accurate achievable total.

### Example

finfocus returns options for an EC2 instance:

- **RIGHTSIZING Option A:** Resize large → medium: Save $50/mo
- **RIGHTSIZING Option B:** Resize large → small: Save $80/mo

Plus another resource:

- **DELETE:** Remove unused EBS volume: Save $20/mo

| Calculation         | Method                              | Total       |
| ------------------- | ----------------------------------- | ----------- |
| **Before (wrong)**  | Sum all: $50 + $80 + $20            | **$150/mo** |
| **After (correct)** | Max per group: max($50,$80) + $20   | **$100/mo** |

## Test plan

- [x] All 177 unit tests pass
- [x] `npm run lint` passes
- [x] `npm run build` generates dist/index.js
- [x] New tests verify max-per-group calculation
- [x] Recommendations table still shows all options (users need to see choices)

## Changes

### Modified files

- `src/formatter.ts`
  - Added `calculateAchievableSavings()` function that groups by resource_id::action_type and returns the sum of max savings per group
  - Updated `formatCommentBody()` to use achievable savings for dashboard display
  - Recommendations section header still shows raw total ("Save up to X")

- `__tests__/unit/formatter.test.ts`
  - Added `calculateAchievableSavings` test suite (7 tests)
  - Added `Dashboard Achievable Savings` integration tests (2 tests)
  - Tests cover: empty input, no mutually exclusive options, same resource+action_type, different action types on same resource, mixed scenarios, multiple groups